### PR TITLE
Fix non-loading of list of all books

### DIFF
--- a/src/app/admin/books/books.component.ts
+++ b/src/app/admin/books/books.component.ts
@@ -80,6 +80,7 @@ export class BooksComponent implements OnInit {
     this.adminService.getAllBooks('').subscribe(res => {
       this.books = res;
       this.booksSize = this.books.length;
+      this.setPage(1);
     });
   }
 


### PR DESCRIPTION
In BooksComponent, the `getAllBooks` callback didn't call `setPage`, and so the table never got populated until something else called that method. (@henryjyc ran into this bug, but didn't know what caused it; I found the cause was simple enough for a one-line fix, thus this PR.)