### PR TITLE
make homepage use routerLink instead of href

### DIFF
--- a/src/app/homepage/homepage.component.html
+++ b/src/app/homepage/homepage.component.html
@@ -1,11 +1,11 @@
 <div class="selection">
   <div class="admin">
-    <a class="buttonLink" href="/admin/">Administrator</a>
+    <a class="buttonLink" routerLink="admin">Administrator</a>
   </div>
   <div class="librarian">
-    <a class="buttonLink" href="/librarian/">Librarian</a>
+    <a class="buttonLink" routerLink="">Librarian</a>
   </div>
   <div class="borrower">
-    <a class="buttonLink" href="/borrower/">Borrower</a>
+    <a class="buttonLink" routerLink="">Borrower</a>
   </div>
 </div>


### PR DESCRIPTION
I forgot to add the changes I made to the homepage. So, here is the changes that I have made in a PR. I left the other two routes blank because I wanted us in the future to make those routes, not us.