### PR TITLE
Reformat and fix linter warnings

### DIFF
--- a/src/app/admin/admin.component.spec.ts
+++ b/src/app/admin/admin.component.spec.ts
@@ -8,9 +8,8 @@ describe('AdminComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ AdminComponent ]
-    })
-    .compileComponents();
+      declarations: [AdminComponent]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/admin/admin.component.ts
+++ b/src/app/admin/admin.component.ts
@@ -6,10 +6,7 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./admin.component.css']
 })
 export class AdminComponent implements OnInit {
+  constructor() {}
 
-  constructor() { }
-
-  ngOnInit() {
-  }
-
+  ngOnInit() {}
 }

--- a/src/app/admin/authors/authors.component.spec.ts
+++ b/src/app/admin/authors/authors.component.spec.ts
@@ -8,9 +8,8 @@ describe('AuthorsComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ AuthorsComponent ]
-    })
-    .compileComponents();
+      declarations: [AuthorsComponent]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/admin/authors/authors.component.ts
+++ b/src/app/admin/authors/authors.component.ts
@@ -12,8 +12,7 @@ import { AuthorDeleteComponent } from './delete/delete.component';
   styleUrls: ['./authors.component.css']
 })
 export class AuthorsComponent implements OnInit {
-
-  constructor(private http: HttpClient, private modalService: NgbModal) { }
+  constructor(private http: HttpClient, private modalService: NgbModal) {}
   authors: any;
 
   currentAuthor: any;
@@ -30,31 +29,38 @@ export class AuthorsComponent implements OnInit {
   }
 
   getAllAuthors() {
-    this.http.get(environment.api_endpoint + environment.get_all_authors).
-      subscribe(res => {
+    this.http
+      .get(environment.api_endpoint + environment.get_all_authors)
+      .subscribe(res => {
         this.authors = res;
       });
   }
 
   openAddModal() {
     const modalRef = this.modalService.open(NewAuthorComponent);
-    modalRef.result.then((res) => this.authors.push(res)).catch((err) => console.log(err));
+    modalRef.result
+      .then(res => this.authors.push(res))
+      .catch(err => console.log(err));
   }
   openModal(content) {
     this.currentModal = this.modalService.open(content);
   }
 
-  showEditForm(author: { id: number; name: string; }) {
+  showEditForm(author: { id: number; name: string }) {
     const modalRef = this.modalService.open(AuthorEditComponent);
     modalRef.componentInstance.currentAuthorId = author.id;
     modalRef.componentInstance.currentAuthorName = author.name;
-    modalRef.result.then((res) => author.name = res.name).catch((err) => console.log(err));
+    modalRef.result
+      .then(res => (author.name = res.name))
+      .catch(err => console.log(err));
   }
 
-  confirmDelete(author: { id: number; name: string; }) {
+  confirmDelete(author: { id: number; name: string }) {
     const modalRef = this.modalService.open(AuthorDeleteComponent);
     modalRef.componentInstance.currentAuthorId = author.id;
     modalRef.componentInstance.currentAuthorName = author.name;
-    modalRef.result.then((_) => this.getAllAuthors()).catch((err) => console.log(err));
+    modalRef.result
+      .then(_ => this.getAllAuthors())
+      .catch(err => console.log(err));
   }
 }

--- a/src/app/admin/authors/authors.component.ts
+++ b/src/app/admin/authors/authors.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { environment } from '../../../environments/environment';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { NewAuthorComponent } from './new/new.component';

--- a/src/app/admin/authors/delete/delete.component.spec.ts
+++ b/src/app/admin/authors/delete/delete.component.spec.ts
@@ -8,9 +8,8 @@ describe('DeleteComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ AuthorDeleteComponent ]
-    })
-    .compileComponents();
+      declarations: [AuthorDeleteComponent]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/admin/authors/delete/delete.component.ts
+++ b/src/app/admin/authors/delete/delete.component.ts
@@ -9,21 +9,25 @@ import { environment } from '../../../../environments/environment';
   styleUrls: ['./delete.component.css']
 })
 export class AuthorDeleteComponent implements OnInit {
-
-  constructor(private http: HttpClient, public activeModal: NgbActiveModal) { }
+  constructor(private http: HttpClient, public activeModal: NgbActiveModal) {}
 
   @Input() currentAuthorId: number;
   @Input() currentAuthorName: string;
 
-  ngOnInit() {
-  }
+  ngOnInit() {}
 
   closeModal() {
     this.activeModal.close('Delete Author modal closed');
   }
 
   applyDelete() {
-    return this.http.delete(environment.api_endpoint + environment.single_author + '/' +
-      this.currentAuthorId).subscribe((res) => this.activeModal.close(res), (err) => console.log(err));
+    return this.http
+      .delete(
+        environment.api_endpoint +
+          environment.single_author +
+          '/' +
+          this.currentAuthorId
+      )
+      .subscribe(res => this.activeModal.close(res), err => console.log(err));
   }
 }

--- a/src/app/admin/authors/edit/edit.component.spec.ts
+++ b/src/app/admin/authors/edit/edit.component.spec.ts
@@ -8,9 +8,8 @@ describe('EditComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ AuthorEditComponent ]
-    })
-    .compileComponents();
+      declarations: [AuthorEditComponent]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/admin/authors/edit/edit.component.ts
+++ b/src/app/admin/authors/edit/edit.component.ts
@@ -9,14 +9,12 @@ import { environment } from '../../../../environments/environment';
   styleUrls: ['./edit.component.css']
 })
 export class AuthorEditComponent implements OnInit {
-
   constructor(private http: HttpClient, public activeModal: NgbActiveModal) {}
 
   @Input() currentAuthorId: number;
   @Input() currentAuthorName: string;
 
-  ngOnInit() {
-  }
+  ngOnInit() {}
 
   closeModal() {
     this.activeModal.close('Edit Author modal closed');
@@ -27,9 +25,15 @@ export class AuthorEditComponent implements OnInit {
       // TODO: show error in form
       return false;
     }
-    return this.http.put(environment.api_endpoint + environment.single_author + '/' + this.currentAuthorId,
-      JSON.stringify({ name: this.currentAuthorName }),
-      { headers: { 'Content-Type': 'application/json'}}).subscribe((res) => this.activeModal.close(res),
-        (err) => console.log(err));
+    return this.http
+      .put(
+        environment.api_endpoint +
+          environment.single_author +
+          '/' +
+          this.currentAuthorId,
+        JSON.stringify({ name: this.currentAuthorName }),
+        { headers: { 'Content-Type': 'application/json' } }
+      )
+      .subscribe(res => this.activeModal.close(res), err => console.log(err));
   }
 }

--- a/src/app/admin/authors/edit/edit.component.ts
+++ b/src/app/admin/authors/edit/edit.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { environment } from '../../../../environments/environment';
 
 @Component({

--- a/src/app/admin/authors/new/new.component.spec.ts
+++ b/src/app/admin/authors/new/new.component.spec.ts
@@ -8,9 +8,8 @@ describe('NewComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ NewAuthorComponent ]
-    })
-    .compileComponents();
+      declarations: [NewAuthorComponent]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/admin/authors/new/new.component.ts
+++ b/src/app/admin/authors/new/new.component.ts
@@ -9,15 +9,13 @@ import { environment } from '../../../../environments/environment';
   styleUrls: ['./new.component.css']
 })
 export class NewAuthorComponent implements OnInit {
-
   constructor(private http: HttpClient, public activeModal: NgbActiveModal) {
     this.currentAuthorName = '';
   }
 
   currentAuthorName: string;
 
-  ngOnInit() {
-  }
+  ngOnInit() {}
 
   closeModal() {
     this.activeModal.close('New Author modal closed');
@@ -28,9 +26,12 @@ export class NewAuthorComponent implements OnInit {
       // TODO: show error in form
       return false;
     }
-    return this.http.post(environment.api_endpoint + environment.single_author,
-      {name: this.currentAuthorName},
-      {headers: {'Content-Type': 'application/json'}}).subscribe((res) =>
-        this.activeModal.close(res), (err) => console.log(err));
+    return this.http
+      .post(
+        environment.api_endpoint + environment.single_author,
+        { name: this.currentAuthorName },
+        { headers: { 'Content-Type': 'application/json' } }
+      )
+      .subscribe(res => this.activeModal.close(res), err => console.log(err));
   }
 }

--- a/src/app/admin/books/books.component.spec.ts
+++ b/src/app/admin/books/books.component.spec.ts
@@ -8,9 +8,8 @@ describe('BooksComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ BooksComponent ]
-    })
-    .compileComponents();
+      declarations: [BooksComponent]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/admin/books/books.component.ts
+++ b/src/app/admin/books/books.component.ts
@@ -10,64 +10,68 @@ import { HttpClient } from '@angular/common/http';
   styleUrls: ['./books.component.css']
 })
 export class BooksComponent implements OnInit {
-
   constructor(
     private http: HttpClient,
     private pagerService: PagerService,
     private adminService: AdminService,
-    private modalService: NgbModal) {this.books=[]; }
-    books:any;
-    authors:any;
-    publishers:any;
-    authorsSize = 1;
-    booksSize = 1;
-    publishersSize = 1;
-    pager: any={};
-    pagedItems: any[];
-    private modalReference: NgbModalRef;
-    errorMsg: string = '';
-    private closeResult: any;
+    private modalService: NgbModal
+  ) {
+    this.books = [];
+  }
+  books: any;
+  authors: any;
+  publishers: any;
+  authorsSize = 1;
+  booksSize = 1;
+  publishersSize = 1;
+  pager: any = {};
+  pagedItems: any[];
+  private modalReference: NgbModalRef;
+  errorMsg: string = '';
+  private closeResult: any;
 
-    book = {
-      id:'',
-      title:'',
-      author:{
-        id:'',
-        name:''},
-      publisher:{
-        id:'',
-        name:'',
-        address:'',
-        phone:''}
-    };
-
-    editBook = {
-      id:'',
-      title:'',
-      author:{
-        id:'',
-        name:''},
-      publisher:{
-        id:'',
-        name:'',
-        address:'',
-        phone:''}
-    };
-
-    publisher = {
+  book = {
+    id: '',
+    title: '',
+    author: {
+      id: '',
+      name: ''
+    },
+    publisher: {
       id: '',
       name: '',
       address: '',
       phone: ''
-    };
-
-    author = {
-      id:'',
-      name:''
     }
-    test:any;
+  };
 
+  editBook = {
+    id: '',
+    title: '',
+    author: {
+      id: '',
+      name: ''
+    },
+    publisher: {
+      id: '',
+      name: '',
+      address: '',
+      phone: ''
+    }
+  };
 
+  publisher = {
+    id: '',
+    name: '',
+    address: '',
+    phone: ''
+  };
+
+  author = {
+    id: '',
+    name: ''
+  };
+  test: any;
 
   ngOnInit() {
     this.getAllBooks();
@@ -76,7 +80,7 @@ export class BooksComponent implements OnInit {
     this.setPage(1);
   }
 
-  getAllBooks(){
+  getAllBooks() {
     this.adminService.getAllBooks('').subscribe(res => {
       this.books = res;
       this.booksSize = this.books.length;
@@ -84,14 +88,14 @@ export class BooksComponent implements OnInit {
     });
   }
 
-  getAllPublishers(){
+  getAllPublishers() {
     this.adminService.getAllPublishers('').subscribe(res => {
       this.publishers = res;
       this.publishersSize = this.publishers.length;
     });
   }
 
-  getAllAuthors(){
+  getAllAuthors() {
     this.adminService.getAllAuthors('').subscribe(res => {
       this.authors = res;
       this.authorsSize = this.authors.length;
@@ -100,29 +104,38 @@ export class BooksComponent implements OnInit {
 
   deleteBook(id) {
     this.adminService.deleteBook(id).subscribe(res => {
-      this.books = this.books.filter(it=>it.id!=id);
+      this.books = this.books.filter(it => it.id != id);
       this.booksSize = this.books.length;
       this.setPage(1);
     });
   }
 
   createBook() {
-    this.adminService.createBook(this.book.title, this.book.author, this.book.publisher).subscribe(res=>{
-      this.books.push(res);
-      this.booksSize = this.books.length;
-      this.setPage(1);
-    });
+    this.adminService
+      .createBook(this.book.title, this.book.author, this.book.publisher)
+      .subscribe(res => {
+        this.books.push(res);
+        this.booksSize = this.books.length;
+        this.setPage(1);
+      });
     this.modalReference.close();
   }
-  
+
   updateBook() {
-    this.adminService.updateBook(this.editBook.id, this.editBook.title, this.editBook.author, this.editBook.publisher).subscribe(res=>{
-      var index = this.books.findIndex(it=>it.id==this.editBook.id);
-      this.books[index].title = this.book.title;
-      this.books[index].author = this.book.author;
-      this.books[index].publisher = this.book.publisher;
-      this.setPage(1);
-    })
+    this.adminService
+      .updateBook(
+        this.editBook.id,
+        this.editBook.title,
+        this.editBook.author,
+        this.editBook.publisher
+      )
+      .subscribe(res => {
+        var index = this.books.findIndex(it => it.id == this.editBook.id);
+        this.books[index].title = this.book.title;
+        this.books[index].author = this.book.author;
+        this.books[index].publisher = this.book.publisher;
+        this.setPage(1);
+      });
     this.modalReference.close();
   }
   setPage(page: number) {
@@ -145,7 +158,7 @@ export class BooksComponent implements OnInit {
       }
     );
   }
-  edit(content, book){
+  edit(content, book) {
     this.editBook = {
       id: book.id,
       title: book.title,
@@ -164,7 +177,7 @@ export class BooksComponent implements OnInit {
       }
     );
   }
-  close(content){
+  close(content) {
     this.modalReference.close();
   }
 }

--- a/src/app/admin/books/books.component.ts
+++ b/src/app/admin/books/books.component.ts
@@ -130,7 +130,7 @@ export class BooksComponent implements OnInit {
         this.editBook.publisher
       )
       .subscribe(res => {
-        var index = this.books.findIndex(it => it.id === this.editBook.id);
+        const index = this.books.findIndex(it => it.id === this.editBook.id);
         this.books[index].title = this.book.title;
         this.books[index].author = this.book.author;
         this.books[index].publisher = this.book.publisher;

--- a/src/app/admin/books/books.component.ts
+++ b/src/app/admin/books/books.component.ts
@@ -27,7 +27,7 @@ export class BooksComponent implements OnInit {
   pager: any = {};
   pagedItems: any[];
   private modalReference: NgbModalRef;
-  errorMsg: string = '';
+  errorMsg = '';
   private closeResult: any;
 
   book = {

--- a/src/app/admin/books/books.component.ts
+++ b/src/app/admin/books/books.component.ts
@@ -104,7 +104,7 @@ export class BooksComponent implements OnInit {
 
   deleteBook(id) {
     this.adminService.deleteBook(id).subscribe(res => {
-      this.books = this.books.filter(it => it.id != id);
+      this.books = this.books.filter(it => it.id !== id);
       this.booksSize = this.books.length;
       this.setPage(1);
     });
@@ -130,7 +130,7 @@ export class BooksComponent implements OnInit {
         this.editBook.publisher
       )
       .subscribe(res => {
-        var index = this.books.findIndex(it => it.id == this.editBook.id);
+        var index = this.books.findIndex(it => it.id === this.editBook.id);
         this.books[index].title = this.book.title;
         this.books[index].author = this.book.author;
         this.books[index].publisher = this.book.publisher;

--- a/src/app/admin/borrowers/borrower.ts
+++ b/src/app/admin/borrowers/borrower.ts
@@ -3,5 +3,6 @@ export class Borrower {
     public cardNo: number,
     public name: string,
     public address: string,
-    public phone: string) { }
+    public phone: string
+  ) {}
 }

--- a/src/app/admin/borrowers/borrowers.component.spec.ts
+++ b/src/app/admin/borrowers/borrowers.component.spec.ts
@@ -8,9 +8,8 @@ describe('BorrowersComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ BorrowersComponent ]
-    })
-    .compileComponents();
+      declarations: [BorrowersComponent]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/admin/borrowers/borrowers.component.ts
+++ b/src/app/admin/borrowers/borrowers.component.ts
@@ -9,10 +9,10 @@ import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
   styleUrls: ['./borrowers.component.css']
 })
 export class BorrowersComponent implements OnInit {
-
   constructor(
     private adminService: AdminService,
-    private modalService: NgbModal) { }
+    private modalService: NgbModal
+  ) {}
 
   borrowers: any;
 
@@ -32,48 +32,69 @@ export class BorrowersComponent implements OnInit {
 
   getAllBorrowers() {
     // console.log('attempting to get all borrowers');
-    this.adminService.getAllBorrowers().subscribe(res => {
-      // console.log('Got all borrowers');
-      this.borrowers = res;
-    }, error => console.log(error));
+    this.adminService.getAllBorrowers().subscribe(
+      res => {
+        // console.log('Got all borrowers');
+        this.borrowers = res;
+      },
+      error => console.log(error)
+    );
   }
 
   deleteBorrower(id) {
-    this.adminService.deleteBorrower(id).subscribe(res => {
-      // console.log('Successfully deleted!');
-      this.adminService.getAllBorrowers().subscribe(getRes => {
-        // console.log('updated Borrower Table Successfully!');
-        this.borrowers = getRes;
-      }, error => console.log(error));
-    }, error => console.log(error));
+    this.adminService.deleteBorrower(id).subscribe(
+      res => {
+        // console.log('Successfully deleted!');
+        this.adminService.getAllBorrowers().subscribe(
+          getRes => {
+            // console.log('updated Borrower Table Successfully!');
+            this.borrowers = getRes;
+          },
+          error => console.log(error)
+        );
+      },
+      error => console.log(error)
+    );
   }
 
   createBorrower() {
     // console.log('In the process of creating a new borrower');
-    this.adminService.createBorrower(this.newBorrower).subscribe(res => {
-      // console.log('Successfully created a Borrower');
-      this.adminService.getAllBorrowers().subscribe(getRes => {
-        // console.log('updated Borrower Table Successfully!');
-        this.borrowers = getRes;
-        // reset the borrower form
-        this.newBorrower = new Borrower(0, '', '', '');
-        // also close modal
-        this.modalReference.close();
-      }, error => console.log(error));
-    }, error => console.log(error));
+    this.adminService.createBorrower(this.newBorrower).subscribe(
+      res => {
+        // console.log('Successfully created a Borrower');
+        this.adminService.getAllBorrowers().subscribe(
+          getRes => {
+            // console.log('updated Borrower Table Successfully!');
+            this.borrowers = getRes;
+            // reset the borrower form
+            this.newBorrower = new Borrower(0, '', '', '');
+            // also close modal
+            this.modalReference.close();
+          },
+          error => console.log(error)
+        );
+      },
+      error => console.log(error)
+    );
   }
 
   updateBorrower() {
     // console.log('Updating ' + this.editBorrower.name);
-    this.adminService.updateBorrower(this.editBorrower).subscribe(res => {
-      // console.log('Successfully updated a borrower');
-      this.adminService.getAllBorrowers().subscribe(getRes => {
-        // console.log('Refresh borrower table');
-        this.borrowers = getRes;
-        // also close modal
-        this.modalReference.close();
-      }, error => console.log(error));
-    }, error => console.log(error));
+    this.adminService.updateBorrower(this.editBorrower).subscribe(
+      res => {
+        // console.log('Successfully updated a borrower');
+        this.adminService.getAllBorrowers().subscribe(
+          getRes => {
+            // console.log('Refresh borrower table');
+            this.borrowers = getRes;
+            // also close modal
+            this.modalReference.close();
+          },
+          error => console.log(error)
+        );
+      },
+      error => console.log(error)
+    );
   }
 
   resetBorrower() {
@@ -106,8 +127,12 @@ export class BorrowersComponent implements OnInit {
 
   editModal(content, selectedBorrower) {
     // console.log('starting edit modal');
-    this.editBorrower = new Borrower(selectedBorrower.cardNo, selectedBorrower.name,
-      selectedBorrower.address, selectedBorrower.phone);
+    this.editBorrower = new Borrower(
+      selectedBorrower.cardNo,
+      selectedBorrower.name,
+      selectedBorrower.address,
+      selectedBorrower.phone
+    );
     this.modalReference = this.modalService.open(content);
     this.modalReference.result.then(
       result => {

--- a/src/app/admin/branches/branches.component.spec.ts
+++ b/src/app/admin/branches/branches.component.spec.ts
@@ -8,9 +8,8 @@ describe('BranchesComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ BranchesComponent ]
-    })
-    .compileComponents();
+      declarations: [BranchesComponent]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/admin/branches/branches.component.ts
+++ b/src/app/admin/branches/branches.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { environment } from '../../../environments/environment';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { NewBranchComponent } from './new/new.component';

--- a/src/app/admin/branches/branches.component.ts
+++ b/src/app/admin/branches/branches.component.ts
@@ -12,7 +12,6 @@ import { BranchDeleteComponent } from './delete/delete.component';
   styleUrls: ['./branches.component.css']
 })
 export class BranchesComponent implements OnInit {
-
   constructor(private http: HttpClient, private modalService: NgbModal) {}
 
   branches: any;
@@ -22,31 +21,34 @@ export class BranchesComponent implements OnInit {
   }
 
   getAllBranches() {
-    this.http.get(environment.api_endpoint + environment.get_all_branches).
-      subscribe(res => this.branches = res);
+    this.http
+      .get(environment.api_endpoint + environment.get_all_branches)
+      .subscribe(res => (this.branches = res));
   }
 
   openAddModal() {
     const modalRef = this.modalService.open(NewBranchComponent);
-    modalRef.result.then((res) => this.branches.push(res)).catch(console.log);
+    modalRef.result.then(res => this.branches.push(res)).catch(console.log);
   }
 
-  showEditForm(branch: { id: number, name: string, address: string}) {
+  showEditForm(branch: { id: number; name: string; address: string }) {
     const modalRef = this.modalService.open(BranchEditComponent);
     modalRef.componentInstance.branchId = branch.id;
     modalRef.componentInstance.branchName = branch.name;
     modalRef.componentInstance.branchAddress = branch.address;
-    modalRef.result.then((res) => {
-      branch.name = res.name;
-      branch.address = res.address;
-    }).catch(console.log);
+    modalRef.result
+      .then(res => {
+        branch.name = res.name;
+        branch.address = res.address;
+      })
+      .catch(console.log);
   }
 
-  confirmDelete(branch: { id: number, name: string, address: string}) {
+  confirmDelete(branch: { id: number; name: string; address: string }) {
     const modalRef = this.modalService.open(BranchDeleteComponent);
     modalRef.componentInstance.branchId = branch.id;
     modalRef.componentInstance.branchName = branch.name;
     modalRef.componentInstance.branchAddress = branch.address;
-    modalRef.result.then((_) => this.getAllBranches()).catch(console.log);
+    modalRef.result.then(_ => this.getAllBranches()).catch(console.log);
   }
 }

--- a/src/app/admin/branches/delete/delete.component.spec.ts
+++ b/src/app/admin/branches/delete/delete.component.spec.ts
@@ -8,9 +8,8 @@ describe('DeleteComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ BranchDeleteComponent ]
-    })
-    .compileComponents();
+      declarations: [BranchDeleteComponent]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/admin/branches/delete/delete.component.ts
+++ b/src/app/admin/branches/delete/delete.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { environment } from '../../../../environments/environment';
 
 @Component({

--- a/src/app/admin/branches/delete/delete.component.ts
+++ b/src/app/admin/branches/delete/delete.component.ts
@@ -9,21 +9,25 @@ import { environment } from '../../../../environments/environment';
   styleUrls: ['./delete.component.css']
 })
 export class BranchDeleteComponent implements OnInit {
-
-  constructor(private http: HttpClient, public activeModal: NgbActiveModal) { }
+  constructor(private http: HttpClient, public activeModal: NgbActiveModal) {}
 
   @Input() branchId: number;
   @Input() branchName: string;
 
-  ngOnInit() {
-  }
+  ngOnInit() {}
 
   closeModal() {
     this.activeModal.close('Delete Branch modal closed');
   }
 
   applyDelete() {
-    return this.http.delete(environment.api_endpoint + environment.single_branch + '/' +
-      this.branchId).subscribe((res) => this.activeModal.close(res), console.log);
+    return this.http
+      .delete(
+        environment.api_endpoint +
+          environment.single_branch +
+          '/' +
+          this.branchId
+      )
+      .subscribe(res => this.activeModal.close(res), console.log);
   }
 }

--- a/src/app/admin/branches/edit/edit.component.spec.ts
+++ b/src/app/admin/branches/edit/edit.component.spec.ts
@@ -8,9 +8,8 @@ describe('EditComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ BranchEditComponent ]
-    })
-    .compileComponents();
+      declarations: [BranchEditComponent]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/admin/branches/edit/edit.component.ts
+++ b/src/app/admin/branches/edit/edit.component.ts
@@ -9,7 +9,6 @@ import { environment } from '../../../../environments/environment';
   styleUrls: ['./edit.component.css']
 })
 export class BranchEditComponent implements OnInit {
-
   constructor(private http: HttpClient, public activeModal: NgbActiveModal) {}
 
   @Input() branchId: number;
@@ -26,9 +25,15 @@ export class BranchEditComponent implements OnInit {
     if (!this.branchName || !this.branchAddress) {
       return false;
     }
-    return this.http.put(environment.api_endpoint + environment.single_branch + '/' + this.branchId,
-      JSON.stringify({ name: this.branchName, address: this.branchAddress }),
-      { headers: { 'Content-Type': 'application/json'}}).subscribe((res) => this.activeModal.close(res),
-        console.log);
+    return this.http
+      .put(
+        environment.api_endpoint +
+          environment.single_branch +
+          '/' +
+          this.branchId,
+        JSON.stringify({ name: this.branchName, address: this.branchAddress }),
+        { headers: { 'Content-Type': 'application/json' } }
+      )
+      .subscribe(res => this.activeModal.close(res), console.log);
   }
 }

--- a/src/app/admin/branches/new/new.component.spec.ts
+++ b/src/app/admin/branches/new/new.component.spec.ts
@@ -8,9 +8,8 @@ describe('NewComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ NewBranchComponent ]
-    })
-    .compileComponents();
+      declarations: [NewBranchComponent]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/admin/branches/new/new.component.ts
+++ b/src/app/admin/branches/new/new.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { environment } from '../../../../environments/environment';
 
 @Component({

--- a/src/app/admin/branches/new/new.component.ts
+++ b/src/app/admin/branches/new/new.component.ts
@@ -9,7 +9,6 @@ import { environment } from '../../../../environments/environment';
   styleUrls: ['./new.component.css']
 })
 export class NewBranchComponent implements OnInit {
-
   constructor(private http: HttpClient, public activeModal: NgbActiveModal) {}
 
   branchName: string;
@@ -26,9 +25,12 @@ export class NewBranchComponent implements OnInit {
       // TODO: show error in form
       return false;
     }
-    return this.http.post(environment.api_endpoint + environment.single_branch,
-      {name: this.branchName, address: this.branchAddress},
-      {headers: {'Content-Type': 'application/json'}}).subscribe((res) =>
-        this.activeModal.close(res), console.log);
+    return this.http
+      .post(
+        environment.api_endpoint + environment.single_branch,
+        { name: this.branchName, address: this.branchAddress },
+        { headers: { 'Content-Type': 'application/json' } }
+      )
+      .subscribe(res => this.activeModal.close(res), console.log);
   }
 }

--- a/src/app/admin/dashboard/dashboard.component.spec.ts
+++ b/src/app/admin/dashboard/dashboard.component.spec.ts
@@ -8,9 +8,8 @@ describe('DashboardComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ DashboardComponent ]
-    })
-    .compileComponents();
+      declarations: [DashboardComponent]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/admin/dashboard/dashboard.component.ts
+++ b/src/app/admin/dashboard/dashboard.component.ts
@@ -6,10 +6,7 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./dashboard.component.css']
 })
 export class DashboardComponent implements OnInit {
+  constructor() {}
 
-  constructor() { }
-
-  ngOnInit() {
-  }
-
+  ngOnInit() {}
 }

--- a/src/app/admin/due-date/borrowers-loan/borrowers-loan.component.spec.ts
+++ b/src/app/admin/due-date/borrowers-loan/borrowers-loan.component.spec.ts
@@ -8,9 +8,8 @@ describe('BorrowersLoanComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ BorrowersLoanComponent ]
-    })
-    .compileComponents();
+      declarations: [BorrowersLoanComponent]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/admin/due-date/borrowers-loan/borrowers-loan.component.ts
+++ b/src/app/admin/due-date/borrowers-loan/borrowers-loan.component.ts
@@ -7,8 +7,7 @@ import { AdminService } from '../../../services/admin.service';
   styleUrls: ['./borrowers-loan.component.css']
 })
 export class BorrowersLoanComponent implements OnInit {
-
-  constructor(private adminService: AdminService) { }
+  constructor(private adminService: AdminService) {}
 
   borrowers: any;
 
@@ -18,10 +17,12 @@ export class BorrowersLoanComponent implements OnInit {
 
   getAllBorrowersWithLoans() {
     // console.log('attempting to get all borrowers');
-    this.adminService.getAllBorrowers().subscribe(res => {
-      // console.log('Got all borrowers');
-      this.borrowers = res;
-    }, error => console.log(error));
+    this.adminService.getAllBorrowers().subscribe(
+      res => {
+        // console.log('Got all borrowers');
+        this.borrowers = res;
+      },
+      error => console.log(error)
+    );
   }
-
 }

--- a/src/app/admin/due-date/due-date.component.spec.ts
+++ b/src/app/admin/due-date/due-date.component.spec.ts
@@ -8,9 +8,8 @@ describe('DueDateComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ DueDateComponent ]
-    })
-    .compileComponents();
+      declarations: [DueDateComponent]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/admin/due-date/due-date.component.ts
+++ b/src/app/admin/due-date/due-date.component.ts
@@ -9,11 +9,11 @@ import { Router } from '@angular/router';
   styleUrls: ['./due-date.component.css']
 })
 export class DueDateComponent implements OnInit {
-
   constructor(
     private adminService: AdminService,
     private modalService: NgbModal,
-    private router: Router) { }
+    private router: Router
+  ) {}
 
   loans: any;
 
@@ -48,10 +48,13 @@ export class DueDateComponent implements OnInit {
 
   getAllLoansForBorrower() {
     // console.log('attempting to get all loans');
-    this.adminService.getAllLoans(this.cardNo).subscribe(res => {
-      // console.log('Got all loans');
-      this.loans = res;
-    }, error => console.log(error));
+    this.adminService.getAllLoans(this.cardNo).subscribe(
+      res => {
+        // console.log('Got all loans');
+        this.loans = res;
+      },
+      error => console.log(error)
+    );
   }
 
   updateLoan() {
@@ -60,15 +63,23 @@ export class DueDateComponent implements OnInit {
     const branchId = this.editLoan.branch.id;
     const cardNo = this.editLoan.borrower.cardNo;
     const overrideDate = this.editLoan.dueDate;
-    this.adminService.updateLoan(bookId, branchId, cardNo, overrideDate).subscribe(res => {
-      // console.log('Successfully updated a borrower');
-      this.adminService.getAllLoans(cardNo).subscribe(getRes => {
-        // console.log('Refresh borrower table');
-        this.loans = getRes;
-        // also close modal
-        this.modalReference.close();
-      }, error => console.log(error));
-    }, error => console.log(error));
+    this.adminService
+      .updateLoan(bookId, branchId, cardNo, overrideDate)
+      .subscribe(
+        res => {
+          // console.log('Successfully updated a borrower');
+          this.adminService.getAllLoans(cardNo).subscribe(
+            getRes => {
+              // console.log('Refresh borrower table');
+              this.loans = getRes;
+              // also close modal
+              this.modalReference.close();
+            },
+            error => console.log(error)
+          );
+        },
+        error => console.log(error)
+      );
   }
 
   editModal(content, selectedLoan) {

--- a/src/app/admin/layout/header/header.component.spec.ts
+++ b/src/app/admin/layout/header/header.component.spec.ts
@@ -8,9 +8,8 @@ describe('HeaderComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ HeaderComponent ]
-    })
-    .compileComponents();
+      declarations: [HeaderComponent]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/admin/layout/header/header.component.ts
+++ b/src/app/admin/layout/header/header.component.ts
@@ -6,10 +6,7 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./header.component.css']
 })
 export class HeaderComponent implements OnInit {
+  constructor() {}
 
-  constructor() { }
-
-  ngOnInit() {
-  }
-
+  ngOnInit() {}
 }

--- a/src/app/admin/layout/layout.component.spec.ts
+++ b/src/app/admin/layout/layout.component.spec.ts
@@ -8,9 +8,8 @@ describe('LayoutComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ LayoutComponent ]
-    })
-    .compileComponents();
+      declarations: [LayoutComponent]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/admin/layout/layout.component.ts
+++ b/src/app/admin/layout/layout.component.ts
@@ -6,10 +6,7 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./layout.component.css']
 })
 export class LayoutComponent implements OnInit {
+  constructor() {}
 
-  constructor() { }
-
-  ngOnInit() {
-  }
-
+  ngOnInit() {}
 }

--- a/src/app/admin/layout/menu/menu.component.spec.ts
+++ b/src/app/admin/layout/menu/menu.component.spec.ts
@@ -8,9 +8,8 @@ describe('MenuComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ MenuComponent ]
-    })
-    .compileComponents();
+      declarations: [MenuComponent]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/admin/layout/menu/menu.component.ts
+++ b/src/app/admin/layout/menu/menu.component.ts
@@ -6,10 +6,7 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./menu.component.css']
 })
 export class MenuComponent implements OnInit {
+  constructor() {}
 
-  constructor() { }
-
-  ngOnInit() {
-  }
-
+  ngOnInit() {}
 }

--- a/src/app/admin/login/login.component.spec.ts
+++ b/src/app/admin/login/login.component.spec.ts
@@ -8,9 +8,8 @@ describe('LoginComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ LoginComponent ]
-    })
-    .compileComponents();
+      declarations: [LoginComponent]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/admin/login/login.component.ts
+++ b/src/app/admin/login/login.component.ts
@@ -6,10 +6,7 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./login.component.css']
 })
 export class LoginComponent implements OnInit {
+  constructor() {}
 
-  constructor() { }
-
-  ngOnInit() {
-  }
-
+  ngOnInit() {}
 }

--- a/src/app/admin/publishers/publishers.component.spec.ts
+++ b/src/app/admin/publishers/publishers.component.spec.ts
@@ -8,9 +8,8 @@ describe('PublishersComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ PublishersComponent ]
-    })
-    .compileComponents();
+      declarations: [PublishersComponent]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/admin/publishers/publishers.component.ts
+++ b/src/app/admin/publishers/publishers.component.ts
@@ -94,7 +94,7 @@ export class PublishersComponent implements OnInit {
         this.editPublisher.phone
       )
       .subscribe(res => {
-        var index = this.publishers.findIndex(
+        const index = this.publishers.findIndex(
           it => it.id === this.editPublisher.id
         );
         this.publishers[index].name = this.editPublisher.name;

--- a/src/app/admin/publishers/publishers.component.ts
+++ b/src/app/admin/publishers/publishers.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { environment } from '../../../environments/environment';
 import { PagerService } from '../../service/pager.service';
 import { AdminService } from '../../service/admin.service';
 import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';

--- a/src/app/admin/publishers/publishers.component.ts
+++ b/src/app/admin/publishers/publishers.component.ts
@@ -64,7 +64,7 @@ export class PublishersComponent implements OnInit {
 
   deletePublisher(id) {
     this.adminService.deletePublisher(id).subscribe(res => {
-      this.publishers = this.publishers.filter(it => it.id != id);
+      this.publishers = this.publishers.filter(it => it.id !== id);
       this.publishersSize = this.publishers.length;
       this.setPage(1);
     });
@@ -95,7 +95,7 @@ export class PublishersComponent implements OnInit {
       )
       .subscribe(res => {
         var index = this.publishers.findIndex(
-          it => it.id == this.editPublisher.id
+          it => it.id === this.editPublisher.id
         );
         this.publishers[index].name = this.editPublisher.name;
         this.publishers[index].address = this.editPublisher.address;

--- a/src/app/admin/publishers/publishers.component.ts
+++ b/src/app/admin/publishers/publishers.component.ts
@@ -5,7 +5,6 @@ import { PagerService } from '../../service/pager.service';
 import { AdminService } from '../../service/admin.service';
 import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 
-
 @Component({
   selector: 'app-publishers',
   templateUrl: './publishers.component.html',
@@ -17,35 +16,37 @@ export class PublishersComponent implements OnInit {
     private pagerService: PagerService,
     private adminService: AdminService,
     private modalService: NgbModal
-    ) {this.publishers=[]; }
-    publishers:any;
-    publishersSize = 1;
-    private allItems: any[];
-    pager: any={};
-    pagedItems: any[];
-    private modalReference: NgbModalRef;
-    errorMsg: string = '';
-    private closeResult: any;
+  ) {
+    this.publishers = [];
+  }
+  publishers: any;
+  publishersSize = 1;
+  private allItems: any[];
+  pager: any = {};
+  pagedItems: any[];
+  private modalReference: NgbModalRef;
+  errorMsg: string = '';
+  private closeResult: any;
 
-    publisher = {
-      id: '',
-      name: '',
-      address: '',
-      phone: ''
-    };
+  publisher = {
+    id: '',
+    name: '',
+    address: '',
+    phone: ''
+  };
 
-    editPublisher ={
-      id: '',
-      name: '',
-      address: '',
-      phone: ''
-    };
+  editPublisher = {
+    id: '',
+    name: '',
+    address: '',
+    phone: ''
+  };
 
   ngOnInit() {
     this.getAllPublishers();
   }
 
-  getAllPublishers(){
+  getAllPublishers() {
     this.adminService.getAllPublishers('').subscribe(res => {
       this.publishers = res;
       this.publishersSize = this.publishers.length;
@@ -63,29 +64,44 @@ export class PublishersComponent implements OnInit {
 
   deletePublisher(id) {
     this.adminService.deletePublisher(id).subscribe(res => {
-      this.publishers = this.publishers.filter(it=>it.id!=id);
+      this.publishers = this.publishers.filter(it => it.id != id);
       this.publishersSize = this.publishers.length;
       this.setPage(1);
     });
   }
 
   createPublisher() {
-    this.adminService.createPublisher(this.publisher.name, this.publisher.address, this.publisher.phone).subscribe(res=>{
-      this.publishers.push(res);
-      this.publishersSize = this.publishers.length;
-      this.setPage(1);
-    });
+    this.adminService
+      .createPublisher(
+        this.publisher.name,
+        this.publisher.address,
+        this.publisher.phone
+      )
+      .subscribe(res => {
+        this.publishers.push(res);
+        this.publishersSize = this.publishers.length;
+        this.setPage(1);
+      });
     this.modalReference.close();
   }
-  
+
   updatePublisher() {
-    this.adminService.updatePublisher(this.editPublisher.id, this.editPublisher.name, this.editPublisher.address, this.editPublisher.phone).subscribe(res=>{
-      var index = this.publishers.findIndex(it=>it.id==this.editPublisher.id);
-      this.publishers[index].name = this.editPublisher.name;
-      this.publishers[index].address = this.editPublisher.address;
-      this.publishers[index].phone = this.editPublisher.phone;
-      this.setPage(1);
-    })
+    this.adminService
+      .updatePublisher(
+        this.editPublisher.id,
+        this.editPublisher.name,
+        this.editPublisher.address,
+        this.editPublisher.phone
+      )
+      .subscribe(res => {
+        var index = this.publishers.findIndex(
+          it => it.id == this.editPublisher.id
+        );
+        this.publishers[index].name = this.editPublisher.name;
+        this.publishers[index].address = this.editPublisher.address;
+        this.publishers[index].phone = this.editPublisher.phone;
+        this.setPage(1);
+      });
     this.modalReference.close();
   }
   setPage(page: number) {
@@ -108,7 +124,7 @@ export class PublishersComponent implements OnInit {
       }
     );
   }
-  edit(content, publisher){
+  edit(content, publisher) {
     this.editPublisher = {
       id: publisher.id,
       name: publisher.name,
@@ -127,7 +143,7 @@ export class PublishersComponent implements OnInit {
       }
     );
   }
-  close(content){
+  close(content) {
     this.modalReference.close();
   }
 }

--- a/src/app/admin/publishers/publishers.component.ts
+++ b/src/app/admin/publishers/publishers.component.ts
@@ -25,7 +25,7 @@ export class PublishersComponent implements OnInit {
   pager: any = {};
   pagedItems: any[];
   private modalReference: NgbModalRef;
-  errorMsg: string = '';
+  errorMsg = '';
   private closeResult: any;
 
   publisher = {

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -4,8 +4,6 @@ import { HomepageComponent } from './homepage/homepage.component';
 import { AdminComponent } from './admin/admin.component';
 import { PublishersComponent } from './admin/publishers/publishers.component';
 import { BooksComponent } from './admin/books/books.component';
-import { fromEventPattern } from 'rxjs';
-import { LayoutComponent } from './admin/layout/layout.component';
 import { BorrowersComponent } from './admin/borrowers/borrowers.component';
 import { DueDateComponent } from './admin/due-date/due-date.component';
 import { BorrowersLoanComponent } from './admin/due-date/borrowers-loan/borrowers-loan.component';

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -10,13 +10,13 @@ import { BorrowersComponent } from './admin/borrowers/borrowers.component';
 import { DueDateComponent } from './admin/due-date/due-date.component';
 import { BorrowersLoanComponent } from './admin/due-date/borrowers-loan/borrowers-loan.component';
 import { AuthorsComponent } from './admin/authors/authors.component';
-import { BranchesComponent} from './admin/branches/branches.component';
+import { BranchesComponent } from './admin/branches/branches.component';
 
 const routes: Routes = [
   {
-    path:'',
+    path: '',
     component: HomepageComponent,
-    children:[]
+    children: []
   },
   {
     path: 'admin',
@@ -53,15 +53,9 @@ const routes: Routes = [
     ]
   }
 ];
-  
-  
-    
-
-  
-
 
 @NgModule({
   imports: [RouterModule.forRoot(routes)],
   exports: [RouterModule]
 })
-export class AppRoutingModule { }
+export class AppRoutingModule {}

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -5,12 +5,8 @@ import { AppComponent } from './app.component';
 describe('AppComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [
-        RouterTestingModule
-      ],
-      declarations: [
-        AppComponent
-      ],
+      imports: [RouterTestingModule],
+      declarations: [AppComponent]
     }).compileComponents();
   }));
 
@@ -30,6 +26,8 @@ describe('AppComponent', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.debugElement.nativeElement;
-    expect(compiled.querySelector('h1').textContent).toContain('Welcome to ntAngularLms!');
+    expect(compiled.querySelector('h1').textContent).toContain(
+      'Welcome to ntAngularLms!'
+    );
   });
 });

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -107,4 +107,4 @@ import { PagerService } from './service/pager.service';
   providers: [PagerService],
   bootstrap: [AppComponent]
 })
-export class AppModule { }
+export class AppModule {}

--- a/src/app/borrower/books/books.component.spec.ts
+++ b/src/app/borrower/books/books.component.spec.ts
@@ -8,9 +8,8 @@ describe('BooksComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ BooksComponent ]
-    })
-    .compileComponents();
+      declarations: [BooksComponent]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/borrower/books/books.component.ts
+++ b/src/app/borrower/books/books.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 
 @Component({
-  selector: 'borrower-app-books',
+  selector: 'app-borrower-books',
   templateUrl: './books.component.html',
   styleUrls: ['./books.component.css']
 })

--- a/src/app/borrower/books/books.component.ts
+++ b/src/app/borrower/books/books.component.ts
@@ -6,10 +6,7 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./books.component.css']
 })
 export class BorrowerBooksComponent implements OnInit {
+  constructor() {}
 
-  constructor() { }
-
-  ngOnInit() {
-  }
-
+  ngOnInit() {}
 }

--- a/src/app/borrower/borrower.component.spec.ts
+++ b/src/app/borrower/borrower.component.spec.ts
@@ -8,9 +8,8 @@ describe('BorrowerComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ BorrowerComponent ]
-    })
-    .compileComponents();
+      declarations: [BorrowerComponent]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/borrower/borrower.component.ts
+++ b/src/app/borrower/borrower.component.ts
@@ -6,10 +6,7 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./borrower.component.css']
 })
 export class BorrowerComponent implements OnInit {
+  constructor() {}
 
-  constructor() { }
-
-  ngOnInit() {
-  }
-
+  ngOnInit() {}
 }

--- a/src/app/borrower/branches/branches.component.spec.ts
+++ b/src/app/borrower/branches/branches.component.spec.ts
@@ -8,9 +8,8 @@ describe('BranchesComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ BranchesComponent ]
-    })
-    .compileComponents();
+      declarations: [BranchesComponent]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/borrower/branches/branches.component.ts
+++ b/src/app/borrower/branches/branches.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 
 @Component({
-  selector: 'borrower-app-branches',
+  selector: 'app-borrower-branches',
   templateUrl: './branches.component.html',
   styleUrls: ['./branches.component.css']
 })

--- a/src/app/borrower/branches/branches.component.ts
+++ b/src/app/borrower/branches/branches.component.ts
@@ -6,10 +6,7 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./branches.component.css']
 })
 export class BorrowerBranchesComponent implements OnInit {
+  constructor() {}
 
-  constructor() { }
-
-  ngOnInit() {
-  }
-
+  ngOnInit() {}
 }

--- a/src/app/borrower/checkout/checkout.component.spec.ts
+++ b/src/app/borrower/checkout/checkout.component.spec.ts
@@ -8,9 +8,8 @@ describe('CheckoutComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ CheckoutComponent ]
-    })
-    .compileComponents();
+      declarations: [CheckoutComponent]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/borrower/checkout/checkout.component.ts
+++ b/src/app/borrower/checkout/checkout.component.ts
@@ -6,10 +6,7 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./checkout.component.css']
 })
 export class CheckoutComponent implements OnInit {
+  constructor() {}
 
-  constructor() { }
-
-  ngOnInit() {
-  }
-
+  ngOnInit() {}
 }

--- a/src/app/borrower/dashboard/dashboard.component.spec.ts
+++ b/src/app/borrower/dashboard/dashboard.component.spec.ts
@@ -8,9 +8,8 @@ describe('DashboardComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ DashboardComponent ]
-    })
-    .compileComponents();
+      declarations: [DashboardComponent]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/borrower/dashboard/dashboard.component.ts
+++ b/src/app/borrower/dashboard/dashboard.component.ts
@@ -6,10 +6,7 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./dashboard.component.css']
 })
 export class BorrowerDashboardComponent implements OnInit {
+  constructor() {}
 
-  constructor() { }
-
-  ngOnInit() {
-  }
-
+  ngOnInit() {}
 }

--- a/src/app/borrower/dashboard/dashboard.component.ts
+++ b/src/app/borrower/dashboard/dashboard.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 
 @Component({
-  selector: 'borrower-app-dashboard',
+  selector: 'app-borrower-dashboard',
   templateUrl: './dashboard.component.html',
   styleUrls: ['./dashboard.component.css']
 })

--- a/src/app/borrower/layout/header/header.component.spec.ts
+++ b/src/app/borrower/layout/header/header.component.spec.ts
@@ -8,9 +8,8 @@ describe('HeaderComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ HeaderComponent ]
-    })
-    .compileComponents();
+      declarations: [HeaderComponent]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/borrower/layout/header/header.component.ts
+++ b/src/app/borrower/layout/header/header.component.ts
@@ -6,10 +6,7 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./header.component.css']
 })
 export class BorrowerHeaderComponent implements OnInit {
+  constructor() {}
 
-  constructor() { }
-
-  ngOnInit() {
-  }
-
+  ngOnInit() {}
 }

--- a/src/app/borrower/layout/header/header.component.ts
+++ b/src/app/borrower/layout/header/header.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 
 @Component({
-  selector: 'borrower-app-header',
+  selector: 'app-borrower-header',
   templateUrl: './header.component.html',
   styleUrls: ['./header.component.css']
 })

--- a/src/app/borrower/layout/layout.component.spec.ts
+++ b/src/app/borrower/layout/layout.component.spec.ts
@@ -8,9 +8,8 @@ describe('LayoutComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ LayoutComponent ]
-    })
-    .compileComponents();
+      declarations: [LayoutComponent]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/borrower/layout/layout.component.ts
+++ b/src/app/borrower/layout/layout.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 
 @Component({
-  selector: 'borrower-app-layout',
+  selector: 'app-borrower-layout',
   templateUrl: './layout.component.html',
   styleUrls: ['./layout.component.css']
 })

--- a/src/app/borrower/layout/layout.component.ts
+++ b/src/app/borrower/layout/layout.component.ts
@@ -6,10 +6,7 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./layout.component.css']
 })
 export class BorrowerLayoutComponent implements OnInit {
+  constructor() {}
 
-  constructor() { }
-
-  ngOnInit() {
-  }
-
+  ngOnInit() {}
 }

--- a/src/app/borrower/login/login.component.spec.ts
+++ b/src/app/borrower/login/login.component.spec.ts
@@ -8,9 +8,8 @@ describe('LoginComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ LoginComponent ]
-    })
-    .compileComponents();
+      declarations: [LoginComponent]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/borrower/login/login.component.ts
+++ b/src/app/borrower/login/login.component.ts
@@ -6,10 +6,7 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./login.component.css']
 })
 export class BorrowerLoginComponent implements OnInit {
+  constructor() {}
 
-  constructor() { }
-
-  ngOnInit() {
-  }
-
+  ngOnInit() {}
 }

--- a/src/app/borrower/login/login.component.ts
+++ b/src/app/borrower/login/login.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 
 @Component({
-  selector: 'borrower-app-login',
+  selector: 'app-borrower-login',
   templateUrl: './login.component.html',
   styleUrls: ['./login.component.css']
 })

--- a/src/app/borrower/return/return.component.spec.ts
+++ b/src/app/borrower/return/return.component.spec.ts
@@ -8,9 +8,8 @@ describe('ReturnComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ ReturnComponent ]
-    })
-    .compileComponents();
+      declarations: [ReturnComponent]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/borrower/return/return.component.ts
+++ b/src/app/borrower/return/return.component.ts
@@ -6,10 +6,7 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./return.component.css']
 })
 export class ReturnComponent implements OnInit {
+  constructor() {}
 
-  constructor() { }
-
-  ngOnInit() {
-  }
-
+  ngOnInit() {}
 }

--- a/src/app/homepage/homepage.component.spec.ts
+++ b/src/app/homepage/homepage.component.spec.ts
@@ -8,9 +8,8 @@ describe('HomepageComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ HomepageComponent ]
-    })
-    .compileComponents();
+      declarations: [HomepageComponent]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/homepage/homepage.component.ts
+++ b/src/app/homepage/homepage.component.ts
@@ -6,10 +6,7 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./homepage.component.css']
 })
 export class HomepageComponent implements OnInit {
+  constructor() {}
 
-  constructor() { }
-
-  ngOnInit() {
-  }
-
+  ngOnInit() {}
 }

--- a/src/app/librarian/branches/branches.component.spec.ts
+++ b/src/app/librarian/branches/branches.component.spec.ts
@@ -8,9 +8,8 @@ describe('BranchesComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ BranchesComponent ]
-    })
-    .compileComponents();
+      declarations: [BranchesComponent]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/librarian/branches/branches.component.ts
+++ b/src/app/librarian/branches/branches.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 
 @Component({
-  selector: 'librarian-app-branches',
+  selector: 'app-librarian-branches',
   templateUrl: './branches.component.html',
   styleUrls: ['./branches.component.css']
 })

--- a/src/app/librarian/branches/branches.component.ts
+++ b/src/app/librarian/branches/branches.component.ts
@@ -6,10 +6,7 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./branches.component.css']
 })
 export class LibrarianBranchesComponent implements OnInit {
+  constructor() {}
 
-  constructor() { }
-
-  ngOnInit() {
-  }
-
+  ngOnInit() {}
 }

--- a/src/app/librarian/copies/copies.component.spec.ts
+++ b/src/app/librarian/copies/copies.component.spec.ts
@@ -8,9 +8,8 @@ describe('CopiesComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ CopiesComponent ]
-    })
-    .compileComponents();
+      declarations: [CopiesComponent]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/librarian/copies/copies.component.ts
+++ b/src/app/librarian/copies/copies.component.ts
@@ -6,10 +6,7 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./copies.component.css']
 })
 export class CopiesComponent implements OnInit {
+  constructor() {}
 
-  constructor() { }
-
-  ngOnInit() {
-  }
-
+  ngOnInit() {}
 }

--- a/src/app/librarian/layout/header/header.component.spec.ts
+++ b/src/app/librarian/layout/header/header.component.spec.ts
@@ -8,9 +8,8 @@ describe('HeaderComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ HeaderComponent ]
-    })
-    .compileComponents();
+      declarations: [HeaderComponent]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/librarian/layout/header/header.component.ts
+++ b/src/app/librarian/layout/header/header.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 
 @Component({
-  selector: 'librarian-app-header',
+  selector: 'app-librarian-header',
   templateUrl: './header.component.html',
   styleUrls: ['./header.component.css']
 })

--- a/src/app/librarian/layout/header/header.component.ts
+++ b/src/app/librarian/layout/header/header.component.ts
@@ -6,10 +6,7 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./header.component.css']
 })
 export class LibrarianHeaderComponent implements OnInit {
+  constructor() {}
 
-  constructor() { }
-
-  ngOnInit() {
-  }
-
+  ngOnInit() {}
 }

--- a/src/app/librarian/layout/layout.component.spec.ts
+++ b/src/app/librarian/layout/layout.component.spec.ts
@@ -8,9 +8,8 @@ describe('LayoutComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ LayoutComponent ]
-    })
-    .compileComponents();
+      declarations: [LayoutComponent]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/librarian/layout/layout.component.ts
+++ b/src/app/librarian/layout/layout.component.ts
@@ -6,10 +6,7 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./layout.component.css']
 })
 export class LibrarianLayoutComponent implements OnInit {
+  constructor() {}
 
-  constructor() { }
-
-  ngOnInit() {
-  }
-
+  ngOnInit() {}
 }

--- a/src/app/librarian/layout/layout.component.ts
+++ b/src/app/librarian/layout/layout.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 
 @Component({
-  selector: 'librarian-app-layout',
+  selector: 'app-librarian-layout',
   templateUrl: './layout.component.html',
   styleUrls: ['./layout.component.css']
 })

--- a/src/app/librarian/librarian.component.spec.ts
+++ b/src/app/librarian/librarian.component.spec.ts
@@ -8,9 +8,8 @@ describe('LibrarianComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ LibrarianComponent ]
-    })
-    .compileComponents();
+      declarations: [LibrarianComponent]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/librarian/librarian.component.ts
+++ b/src/app/librarian/librarian.component.ts
@@ -6,10 +6,7 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./librarian.component.css']
 })
 export class LibrarianComponent implements OnInit {
+  constructor() {}
 
-  constructor() { }
-
-  ngOnInit() {
-  }
-
+  ngOnInit() {}
 }

--- a/src/app/librarian/login/login.component.spec.ts
+++ b/src/app/librarian/login/login.component.spec.ts
@@ -8,9 +8,8 @@ describe('LoginComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ LoginComponent ]
-    })
-    .compileComponents();
+      declarations: [LoginComponent]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/librarian/login/login.component.ts
+++ b/src/app/librarian/login/login.component.ts
@@ -6,10 +6,7 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./login.component.css']
 })
 export class LibrarianLoginComponent implements OnInit {
+  constructor() {}
 
-  constructor() { }
-
-  ngOnInit() {
-  }
-
+  ngOnInit() {}
 }

--- a/src/app/librarian/login/login.component.ts
+++ b/src/app/librarian/login/login.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 
 @Component({
-  selector: 'librarian-app-login',
+  selector: 'app-librarian-login',
   templateUrl: './login.component.html',
   styleUrls: ['./login.component.css']
 })

--- a/src/app/service/admin.service.ts
+++ b/src/app/service/admin.service.ts
@@ -7,91 +7,69 @@ import { environment } from '../../environments/environment';
   providedIn: 'root'
 })
 export class AdminService {
-
-  constructor(private http: HttpClient) { }
+  constructor(private http: HttpClient) {}
   getAllAuthors(query) {
     return this.http.get(
-      environment.api_endpoint +
-        environment.get_all_authors
+      environment.api_endpoint + environment.get_all_authors
     );
   }
   getAllPublishers(query) {
     return this.http.get(
-      environment.api_endpoint +
-        environment.get_all_publishers
+      environment.api_endpoint + environment.get_all_publishers
     );
   }
 
-  createPublisher(name, address, phone){
+  createPublisher(name, address, phone) {
     return this.http.post(
-      environment.api_endpoint + 
-        environment.get_publisher,
-        {
-          name: name,
-          address: address,
-          phone: phone
-        }
+      environment.api_endpoint + environment.get_publisher,
+      {
+        name: name,
+        address: address,
+        phone: phone
+      }
     );
   }
 
   deletePublisher(id) {
     return this.http.delete(
-      environment.api_endpoint +
-        environment.get_publisher +
-        id
+      environment.api_endpoint + environment.get_publisher + id
     );
   }
 
   updatePublisher(id, name, address, phone) {
     return this.http.put(
-      environment.api_endpoint +
-        environment.get_publisher +
-        id,
-        {
-          name: name,
-          address: address,
-          phone: phone
-        }
+      environment.api_endpoint + environment.get_publisher + id,
+      {
+        name: name,
+        address: address,
+        phone: phone
+      }
     );
   }
 
   getAllBooks(query) {
-    return this.http.get(
-      environment.api_endpoint +
-        environment.get_all_books
-    );
+    return this.http.get(environment.api_endpoint + environment.get_all_books);
   }
 
-  createBook(title, author, publisher){
-    return this.http.post(
-      environment.api_endpoint + 
-        environment.get_book,
-        {
-          title: title,
-          author: author,
-          publisher: publisher
-        }
-    );
+  createBook(title, author, publisher) {
+    return this.http.post(environment.api_endpoint + environment.get_book, {
+      title: title,
+      author: author,
+      publisher: publisher
+    });
   }
 
   deleteBook(id) {
     return this.http.delete(
-      environment.api_endpoint +
-        environment.get_book +
-        id
+      environment.api_endpoint + environment.get_book + id
     );
   }
 
   updateBook(id, title, author, publisher) {
-    return this.http.put(
-      environment.api_endpoint +
-        environment.get_book +
-        id,
-        {
-          title: title,
-          author: author,
-          publisher: publisher
-        }
-    );
+    return this.http.put(environment.api_endpoint + environment.get_book + id, {
+      title: title,
+      author: author,
+      publisher: publisher
+    });
   }
 }

--- a/src/app/service/admin.service.ts
+++ b/src/app/service/admin.service.ts
@@ -23,9 +23,7 @@ export class AdminService {
     return this.http.post(
       environment.api_endpoint + environment.get_publisher,
       {
-        name: name,
-        address: address,
-        phone: phone
+        name, address, phone
       }
     );
   }
@@ -40,9 +38,7 @@ export class AdminService {
     return this.http.put(
       environment.api_endpoint + environment.get_publisher + id,
       {
-        name: name,
-        address: address,
-        phone: phone
+        name, address, phone
       }
     );
   }
@@ -53,9 +49,7 @@ export class AdminService {
 
   createBook(title, author, publisher) {
     return this.http.post(environment.api_endpoint + environment.get_book, {
-      title: title,
-      author: author,
-      publisher: publisher
+      title, author, publisher
     });
   }
 
@@ -67,9 +61,7 @@ export class AdminService {
 
   updateBook(id, title, author, publisher) {
     return this.http.put(environment.api_endpoint + environment.get_book + id, {
-      title: title,
-      author: author,
-      publisher: publisher
+      title, author, publisher
     });
   }
 }

--- a/src/app/service/admin.service.ts
+++ b/src/app/service/admin.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { environment } from '../../environments/environment';
 // import { totalmem } from 'os';
 

--- a/src/app/service/pager.service.ts
+++ b/src/app/service/pager.service.ts
@@ -1,7 +1,7 @@
 export class PagerService {
   getPager(totalItems: number, currentPage: number = 1, pageSize: number = 10) {
     // calculate total pages
-    let totalPages = Math.ceil(totalItems / pageSize);
+    const totalPages = Math.ceil(totalItems / pageSize);
 
     // ensure current page isn't out of range
     if (currentPage < 1) {
@@ -10,7 +10,8 @@ export class PagerService {
       currentPage = totalPages;
     }
 
-    let startPage: number, endPage: number;
+    const startPage: number;
+    const endPage: number;
     if (totalPages <= 10) {
       // less than 10 total pages so show all
       startPage = 1;
@@ -30,11 +31,11 @@ export class PagerService {
     }
 
     // calculate start and end item indexes
-    let startIndex = (currentPage - 1) * pageSize;
-    let endIndex = Math.min(startIndex + pageSize - 1, totalItems - 1);
+    const startIndex = (currentPage - 1) * pageSize;
+    const endIndex = Math.min(startIndex + pageSize - 1, totalItems - 1);
 
     // create an array of pages to ng-repeat in the pager control
-    let pages = Array.from(Array(endPage + 1 - startPage).keys()).map(
+    const pages = Array.from(Array(endPage + 1 - startPage).keys()).map(
       i => startPage + i
     );
 

--- a/src/app/service/pager.service.ts
+++ b/src/app/service/pager.service.ts
@@ -10,8 +10,8 @@ export class PagerService {
       currentPage = totalPages;
     }
 
-    const startPage: number;
-    const endPage: number;
+    let startPage: number;
+    let endPage: number;
     if (totalPages <= 10) {
       // less than 10 total pages so show all
       startPage = 1;

--- a/src/app/service/pager.service.ts
+++ b/src/app/service/pager.service.ts
@@ -41,15 +41,8 @@ export class PagerService {
 
     // return object with all pager properties required by the view
     return {
-      totalItems: totalItems,
-      currentPage: currentPage,
-      pageSize: pageSize,
-      totalPages: totalPages,
-      startPage: startPage,
-      endPage: endPage,
-      startIndex: startIndex,
-      endIndex: endIndex,
-      pages: pages
+      totalItems, currentPage, pageSize, totalPages, startPage, endPage,
+      startIndex, endIndex, pages
     };
   }
 }

--- a/src/app/services/admin.service.ts
+++ b/src/app/services/admin.service.ts
@@ -6,48 +6,47 @@ import { environment } from '../../environments/environment';
   providedIn: 'root'
 })
 export class AdminService {
-
-  constructor(private http: HttpClient) { }
+  constructor(private http: HttpClient) {}
 
   getAllBorrowers() {
     return this.http.get(
       environment.api_endpoint +
-      environment.admin_endpoint +
-      environment.get_all_borrowers
+        environment.admin_endpoint +
+        environment.get_all_borrowers
     );
   }
 
   deleteBorrower(id) {
     return this.http.delete(
       environment.api_endpoint +
-      environment.admin_endpoint +
-      environment.borrower_api +
-      id
+        environment.admin_endpoint +
+        environment.borrower_api +
+        id
     );
   }
 
   createBorrower(body) {
     return this.http.post(
       environment.api_endpoint +
-      environment.admin_endpoint +
-      environment.borrower_api,
+        environment.admin_endpoint +
+        environment.borrower_api,
       // Second parameter is an object you want to pass to the server,
       // it does not have to be JSON stringify
       {
-        name:body.name,
-        address:body.address,
-        phone:body.address
+        name: body.name,
+        address: body.address,
+        phone: body.address
       },
-      {headers: {'Content-Type': 'application/json'}}
+      { headers: { 'Content-Type': 'application/json' } }
     );
   }
 
   updateBorrower(borrower) {
     return this.http.put(
       environment.api_endpoint +
-      environment.admin_endpoint +
-      environment.borrower_api +
-      borrower.cardNo,
+        environment.admin_endpoint +
+        environment.borrower_api +
+        borrower.cardNo,
       borrower
     );
   }
@@ -55,26 +54,33 @@ export class AdminService {
   getAllLoans(cardNo) {
     return this.http.get(
       environment.api_endpoint +
-      environment.admin_endpoint +
-      '/' + 'admin' +
-      environment.get_all_borrowers + '/' +
-      cardNo +
-      environment.get_all_loans
+        environment.admin_endpoint +
+        '/' +
+        'admin' +
+        environment.get_all_borrowers +
+        '/' +
+        cardNo +
+        environment.get_all_loans
     );
   }
 
   updateLoan(bookId: number, branchId: number, cardNo: number, overrideDate) {
     return this.http.put(
       environment.api_endpoint +
-      environment.admin_endpoint + '/loan' +
-      environment.book_api + bookId +
-      environment.branch_api + branchId +
-      environment.borrower_api + cardNo + '/due',
+        environment.admin_endpoint +
+        '/loan' +
+        environment.book_api +
+        bookId +
+        environment.branch_api +
+        branchId +
+        environment.borrower_api +
+        cardNo +
+        '/due',
       // + '/due?dueDate=' + overrideDate,
       // Second parameter is an object you want to pass to the server,
       // it does not have to be JSON stringify
       {
-        dueDate:overrideDate
+        dueDate: overrideDate
       }
     );
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,5 +8,6 @@ if (environment.production) {
   enableProdMode();
 }
 
-platformBrowserDynamic().bootstrapModule(AppModule)
+platformBrowserDynamic()
+  .bootstrapModule(AppModule)
   .catch(err => console.error(err));

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -55,8 +55,7 @@
 /***************************************************************************************************
  * Zone JS is required by default for Angular itself.
  */
-import 'zone.js/dist/zone';  // Included with Angular CLI.
-
+import 'zone.js/dist/zone'; // Included with Angular CLI.
 
 /***************************************************************************************************
  * APPLICATION IMPORTS

--- a/src/styles.css
+++ b/src/styles.css
@@ -106,7 +106,7 @@ a, a:hover {
 }
 
 .admin {
-  padding: 10px 0px;
+  padding: 10px 0;
 }
 .admin button {
   background: purple;
@@ -118,7 +118,7 @@ a, a:hover {
 }
 
 .librarian {
-  padding: 10px 0px;
+  padding: 10px 0;
 }
 .librarian button {
   background: orange;
@@ -130,7 +130,7 @@ a, a:hover {
 }
 
 .borrower {
-  padding: 10px 0px;
+  padding: 10px 0;
 }
 .borrower button {
   background: salmon;
@@ -145,7 +145,7 @@ a, a:hover {
 
 .login_main {
   width: 50%;
-  margin: 150px auto 0px auto;
+  margin: 150px auto 0 auto;
 }
 
 .login_form {
@@ -155,10 +155,10 @@ a, a:hover {
   font-size: 40px;
 }
 .login_form input {
-  margin: 5px 0px;
+  margin: 5px 0;
 }
 .login_form button {
-  margin: 5px 0px;
+  margin: 5px 0;
   width: 100%;
   padding: 10px;
   font-size: 18px; 
@@ -171,7 +171,7 @@ a, a:hover {
 
 .table_container {
   width: 85%;
-  margin: 125px auto 0px auto;
+  margin: 125px auto 0 auto;
 }
 
 .table_container h2 {
@@ -202,7 +202,7 @@ a, a:hover {
 }
 
 .submit_bttns {
-  margin: 40px 0px;
+  margin: 40px 0;
   width: 100%;
   text-align: center;
 }
@@ -222,7 +222,7 @@ a, a:hover {
 
 .editBranchForm {
   width: 85%;
-  margin: 125px auto 0px auto;
+  margin: 125px auto 0 auto;
 }
 
 .editBranchForm form {
@@ -245,7 +245,7 @@ a, a:hover {
 }
 
 .borrowerCheckout, .borrowerReturn {
-  margin: 40px 0px;
+  margin: 40px 0;
 }
 
 .borrowerCheckout button, .borrowerReturn button {
@@ -274,7 +274,7 @@ a, a:hover {
 
 .selectBranch_main {
   width: 50%;
-  margin: 150px auto 0px auto;
+  margin: 150px auto 0 auto;
 }
 
 /***********************ADMIN DASH*************************/
@@ -306,7 +306,7 @@ a, a:hover {
 
 .adminDashGreeting_right {
   flex-grow: 1;
-  margin: 50px 0px 0px 155px;
+  margin: 50px 0 0 155px;
   text-align: center;
   font-size: 30px;
   font-weight: bold;
@@ -315,7 +315,7 @@ a, a:hover {
 /*for the more generic tables*/
 .adminDash_right {
   flex-grow: 1;
-  margin: 50px 0px 0px 155px;
+  margin: 50px 0 0 155px;
 }
 
 /*****************ADMIN ALL BOOKS********************/


### PR DESCRIPTION
Running `ng lint` threw up a long list of errors (to which I was pointed by one of the GitHub apps I connected to my account); this PR fixes them so that the project now does not produce any errors under either `ng build` or `ng lint`.